### PR TITLE
Several fixes #patch

### DIFF
--- a/.github/workflows/dev_publish_pypi.yml
+++ b/.github/workflows/dev_publish_pypi.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest typing markdown2 datetime Jinja2 libsass numpy pandas beautifulsoup4 pytest-mock
+          pip install pytest typing markdown2 datetime lxml Jinja2 libsass numpy pandas beautifulsoup4 pytest-mock
       - name: Test with pytest
         run: pytest tests/ --doctest-modules --junitxml=junit/test-results-${{ matrix.python-version }}.xml
       - name: Upload pytest test results

--- a/.github/workflows/dev_publish_pypi.yml
+++ b/.github/workflows/dev_publish_pypi.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest typing markdown2 datetime libsass numpy pandas beautifulsoup4 pytest-mock
+          pip install pytest typing markdown2 datetime Jinja2 libsass numpy pandas beautifulsoup4 pytest-mock
       - name: Test with pytest
         run: pytest tests/ --doctest-modules --junitxml=junit/test-results-${{ matrix.python-version }}.xml
       - name: Upload pytest test results

--- a/.github/workflows/dev_publish_pypi.yml
+++ b/.github/workflows/dev_publish_pypi.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest typing markdown2 datetime lxml Jinja2 libsass numpy pandas beautifulsoup4 pytest-mock
+          pip install pytest typing markdown2 datetime lxml openpyxl Jinja2 libsass numpy pandas beautifulsoup4 pytest-mock
       - name: Test with pytest
         run: pytest tests/ --doctest-modules --junitxml=junit/test-results-${{ matrix.python-version }}.xml
       - name: Upload pytest test results

--- a/.github/workflows/dev_publish_pypi.yml
+++ b/.github/workflows/dev_publish_pypi.yml
@@ -6,40 +6,40 @@ on:
     paths-ignore: [ 'docs/**' ]
 
 jobs:
-#  testing:
-#
-#    runs-on: ubuntu-latest
-#    strategy:
-#      matrix:
-#        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-#
-#    steps:
-#      - uses: actions/checkout@v4
-#      - name: Setup Python # Set Python version
-#        uses: actions/setup-python@v5
-#        with:
-#          python-version: ${{ matrix.python-version }}
-#      # Install pip and pytest
-#      - name: Install dependencies
-#        run: |
-#          python -m pip install --upgrade pip
-#          pip install pytest typing markdown2 datetime libsass numpy pandas beautifulsoup4
-#      - name: Test with pytest
-#        run: pytest tests/ --doctest-modules --junitxml=junit/test-results-${{ matrix.python-version }}.xml
-#      - name: Upload pytest test results
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: pytest-results-${{ matrix.python-version }}
-#          path: junit/test-results-${{ matrix.python-version }}.xml
-#        # Use always() to always run this step to publish test results when there are test failures
-#        if: ${{ always() }}
+  testing:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python # Set Python version
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      # Install pip and pytest
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest typing markdown2 datetime libsass numpy pandas beautifulsoup4 pytest-mock
+      - name: Test with pytest
+        run: pytest tests/ --doctest-modules --junitxml=junit/test-results-${{ matrix.python-version }}.xml
+      - name: Upload pytest test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-results-${{ matrix.python-version }}
+          path: junit/test-results-${{ matrix.python-version }}.xml
+        # Use always() to always run this step to publish test results when there are test failures
+        if: ${{ always() }}
 
 
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
-#    needs:
-#      - testing
+    needs:
+      - testing
 
     steps:
       - uses: actions/checkout@v4 # Checkout the code

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 BeautifulEmail is a python package that makes it easy and quick to send beautifully formatted emails with beuatiful tables/dataframes. BeautifulEmail is for Data Scientists with a deadline.
   
+<img src="https://github.com/vanalmsick/beautifulexcel/raw/main/docs/docs/imgs/email_preview.png" alt="Email Preview" style="max-height:600px;border: 1px solid #555;"/>
 
 ## Getting it
 
@@ -26,6 +27,7 @@ from beautifulemail import Connection, DataFrameToHTML
 df_html = DataFrameToHTML(df=styled)
 df_html.col_num_fmt_auto()
 df_html.col_styles(column=['last_contact', 'revenue'], classes=['bg_light_blue'])
+df_html.col_styles(column=['last_contact'], classes=['text_color_amber'])
 
 email_body_markdown = f"""
 Hi,

--- a/beautifulemail/base.py
+++ b/beautifulemail/base.py
@@ -112,7 +112,7 @@ class DataFrameToHTML:
         to_html_kwargs = dict(index=self.has_index, header=self.has_header, index_names=self.has_index_names)
 
         # remove kwargs that are not comppatile with old pandas versions
-        if version.parse(pd.__version__) < version.parse('1.3.0'):
+        if version.parse(pd.__version__) < version.parse('2.0.0'):
             _ = to_html_kwargs.pop('index')
             warnings.warn(f'Pandas version "{pd.__version__}" does not support index argument - thus will be ignored.')
 

--- a/beautifulemail/base.py
+++ b/beautifulemail/base.py
@@ -112,7 +112,7 @@ class DataFrameToHTML:
         to_html_kwargs = dict(index=self.has_index, header=self.has_header, index_names=self.has_index_names)
 
         # remove kwargs that are not comppatile with old pandas versions
-        if version.parse(pd.__version__) < version.parse('1.0.0'):
+        if version.parse(pd.__version__) < version.parse('1.3.0'):
             _ = to_html_kwargs.pop('index')
             warnings.warn(f'Pandas version "{pd.__version__}" does not support index argument - thus will be ignored.')
 

--- a/beautifulemail/base.py
+++ b/beautifulemail/base.py
@@ -112,7 +112,7 @@ class DataFrameToHTML:
         to_html_kwargs = dict(index=self.has_index, header=self.has_header, index_names=self.has_index_names)
 
         # remove kwargs that are not comppatile with old pandas versions
-        if version.parse(pd.__version__) < version.parse('2.0.0'):
+        if version.parse(pd.__version__) < version.parse('1.5.0'):
             _ = to_html_kwargs.pop('index')
             _ = to_html_kwargs.pop('header')
             _ = to_html_kwargs.pop('index_names')
@@ -197,7 +197,16 @@ def send_email(
     if body_text != '':
         msg.attach(MIMEText(body_text, 'plain'))
     if body_markdown != '':
-        body_html = markdown2.markdown(body_markdown, extras=['breaks', 'tables', 'strike', 'code-friendly', 'fenced-code-blocks', 'footnotes', 'task_list'])
+        body_html = markdown2.markdown(
+            body_markdown,
+            extras={
+                'breaks': {'on_newline': True, 'on_backslash': True},
+                'tables': {},
+                'strike': {},
+                'code-friendly': {},
+                'fenced-code-blocks': {},
+                'footnotes': {}
+            })
     if body_html != '':
         body_html = template_html.replace('{body_html}', body_html)
 

--- a/beautifulemail/base.py
+++ b/beautifulemail/base.py
@@ -114,7 +114,8 @@ class DataFrameToHTML:
         # remove kwargs that are not comppatile with old pandas versions
         if version.parse(pd.__version__) < version.parse('2.0.0'):
             _ = to_html_kwargs.pop('index')
-            warnings.warn(f'Pandas version "{pd.__version__}" does not support index argument - thus will be ignored.')
+            _ = to_html_kwargs.pop('header')
+            warnings.warn(f'Pandas version "{pd.__version__}" does not support "index" and "header" arguments - thus will be ignored.')
 
 
         # apply number formatting

--- a/beautifulemail/base.py
+++ b/beautifulemail/base.py
@@ -16,8 +16,24 @@ import sass
 
 
 def _standarise_email(obj):
-    """Converts """
+    """Converts contact detail dictionaries into email strings"""
+    if type(obj) is dict:
+        obj = {k.lower(): v for k, v in obj.items()}
+        fname = obj.get('fname', obj.get('firstname', obj.get('first_name', None)))
+        lname = obj.get('lname', obj.get('lastname', obj.get('last_name', None)))
+        fullname = obj.get('name', obj.get('fullname', obj.get('full_name', None)))
+        email = obj.get('email', obj.get('emailaddress', obj.get('email_address')))
+
+        if fname is not None and lname is not None:
+            return f'{lname}, {fname} <{email}>'
+        if fullname is not None:
+            return f'{fullname} <{email}>'
+        if fname is not None:
+            return f'{fname} <{email}>'
+
+        return f'{email}'
     return obj
+
 
 class DataFrameToHTML:
     def __init__(self, df, index=True, header=True, index_names=False):

--- a/beautifulemail/base.py
+++ b/beautifulemail/base.py
@@ -115,7 +115,8 @@ class DataFrameToHTML:
         if version.parse(pd.__version__) < version.parse('2.0.0'):
             _ = to_html_kwargs.pop('index')
             _ = to_html_kwargs.pop('header')
-            warnings.warn(f'Pandas version "{pd.__version__}" does not support "index" and "header" arguments - thus will be ignored.')
+            _ = to_html_kwargs.pop('index_names')
+            warnings.warn(f'Pandas version "{pd.__version__}" does not support "index", "header", and "index_names" arguments - thus will be ignored.')
 
 
         # apply number formatting

--- a/beautifulemail/templates/msft_plain_blue.html
+++ b/beautifulemail/templates/msft_plain_blue.html
@@ -79,7 +79,7 @@
             padding: 3px 5px;
             border: 1px solid #D9D9D9;
             border-collapse: collapse;
-            text-allign: center;
+            text-align: center;
         }
 
         thead th {
@@ -90,9 +90,45 @@
 
         tbody th {
             background-color: #F2F2F2;
-            text-allign: left;
+            text-align: left;
         }
 
+
+        .text_align_left, .horizontal_align_left {text-align: left;}
+        .text_align_center, .horizontal_align_center {text-align: center;}
+        .text_align_right, .horizontal_align_right {text-align: right;}
+        .text_align_top, .vertical_align_top {vertical-align: top;}
+        .text_align_middle, .vertical_align_middle {vertical-align: middle;}
+        .text_align_bottom, .vertical_align_bottom {vertical-align: bottom;}
+        .text_super, .text_align_super, .vertical_align_super {
+            vertical-align: super;
+            font-size: 0.7em;
+        }
+        .text_sub, .text_align_sub, .vertical_align_sub {
+            vertical-align: sub;
+            font-size: 0.7em;
+        }
+
+        .text_bold {font-weight: bold;}
+        .text_italic {font-style: italic;}
+        .text_underlined, .text_underline {text-decoration: underline;}
+        .text_strikethrough,.text_strike_through, .text_line_through {text-decoration: line-through;}
+
+        .text_color_black {color: #000000;}
+        .text_color_white {color: #FFFFFF;}
+        .text_color_dark_red {color: #c00000;}
+        .text_color_red {color: #ff0000;}
+        .text_color_orange {color: #e87331;}
+        .text_color_amber {color: #ffc000;}
+        .text_color_yellow {color: #ffff00;}
+        .text_color_purple {color: #7030a0;}
+        .text_color_dark_green {color: #186c24;}
+        .text_color_green {color: #4ea72e;}
+        .text_color_dark_blue {color: #002060;}
+        .text_color_blue {color: #0070c0;}
+        .text_color_dark_grey {color: #595959;}
+        .text_color_grey {color: #808080;}
+        .text_color_light_grey {color: #bfbfbf;}
 
         .bg_light_grey {background-color: #F2F2F2;}
         .bg_light_purple {background-color: #E4DFEC;}

--- a/docs/docs/change_log.md
+++ b/docs/docs/change_log.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Minor fixes in documentation
+- Add backwards compability with py-3.7 removing pandas kwargs that are not supported
 
 ## [0.1.0] - 2024-10-26
 

--- a/docs/docs/change_log.md
+++ b/docs/docs/change_log.md
@@ -12,10 +12,13 @@ All notable changes to this project will be documented in this file.
 
 - Added tests and github workflow for automatic testing
 - Implemented _standarise_email() function
+- Added css styles
+- Add email preview to docs and README
 
 ### Fixed
 
 - Minor fixes in documentation
+- Fix number formatting
 - Add backwards compability with py-3.7 removing pandas kwargs that are not supported
 
 ## [0.1.0] - 2024-10-26

--- a/docs/docs/change_log.md
+++ b/docs/docs/change_log.md
@@ -6,7 +6,18 @@ All notable changes to this project will be documented in this file.
 
 - None
 
-## [0.0.1] - 2024-09-08
+## [0.1.1] - 2024-10-27
+
+### Added
+
+- Added tests and github workflow for automatic testing
+- Implemented _standarise_email() function
+
+### Fixed
+
+- Minor fixes in documentation
+
+## [0.1.0] - 2024-10-26
 
 ### Added
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -5,6 +5,7 @@
 
 BeautifulEmail is a python package that makes it easy and quick to send beautifully formatted emails with beuatiful tables/dataframes. BeautifulEmail is for Data Scientists with a deadline.
   
+<img src="https://github.com/vanalmsick/beautifulexcel/raw/main/docs/docs/imgs/email_preview.png" alt="Email Preview" style="max-height:600px;border: 1px solid #555;"/>
 
 ## Getting it
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -8,21 +8,21 @@ theme:
   name: material
   favicon:
   icon:
-    logo: material/microsoft-excel
+    logo: material/email-edit-outline
   palette:
     # Light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: green
-      accent: light green
+      primary: blue
+      accent: blue green
       toggle:
         icon: material/weather-night
         name: Switch to dark mode
     # Dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: green
-      accent: light green
+      primary: blue
+      accent: light blue
       toggle:
         icon: material/weather-sunny
         name: Switch to light mode

--- a/tests/test_email_conversion.py
+++ b/tests/test_email_conversion.py
@@ -1,0 +1,9 @@
+from beautifulemail.base import _standarise_email
+
+def test_email_conversion():
+
+    assert 'test@test.com' == _standarise_email('test@test.com')
+    assert 'Last, First <test@test.com>' == _standarise_email({'fname': 'First', 'LName': 'Last', 'email_address': 'test@test.com'})
+    assert 'First <test@test.com>' == _standarise_email({'first_name': 'First', 'email': 'test@test.com'})
+    assert 'First Last <test@test.com>' == _standarise_email({'full_name': 'First Last', 'email': 'test@test.com'})
+    assert 'test@test.com' == _standarise_email({'emailaddress': 'test@test.com'})

--- a/tests/test_full_implementation.py
+++ b/tests/test_full_implementation.py
@@ -115,7 +115,6 @@ Text block/quote:
                 to_='test@test.com',
                 subject='My Email subject',
                 body_markdown=email_body_markdown,
-                attachments=['../README.md'],
                 dry_run=False
                 )
 

--- a/tests/test_full_implementation.py
+++ b/tests/test_full_implementation.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+import os, datetime
+import unittest.mock
+import numpy as np
+import pandas as pd
+from beautifulemail.base import Connection, DataFrameToHTML
+
+
+def test_full_implementation():
+    example_df = pd.DataFrame(
+        {
+            "client": ["A", "B", "C", "D", "E", "F", "G", "H"],
+            "industry": [
+                "ASEET MANAGEMENT",
+                "ASEET MANAGEMENT",
+                "BANK",
+                "INSURANCE",
+                "VERY VERY VERY VERY VERY LONG INSUSTRY NAME",
+                "BANK",
+                "COMMODITY BROKER",
+                "INSURANCE",
+                ],
+            "employees": [25_000, 17_000_000, 14, 9_000, 12_000_000, 9_000, np.nan, 4_000_000],
+            "inception": [
+                datetime.datetime(2022, 1, 1),
+                datetime.datetime(2000, 10, 30),
+                datetime.datetime(2010, 5, 6),
+                np.nan,
+                datetime.datetime(1997, 1, 1),
+                datetime.datetime(1962, 1, 1),
+                datetime.datetime(2003, 11, 10),
+                datetime.datetime(2022, 1, 1),
+                ],
+            "last_contact": [
+                datetime.datetime(2022, 1, 1, 10, 2, 5),
+                datetime.datetime(2000, 10, 30),
+                datetime.datetime(2010, 5, 6),
+                np.nan,
+                datetime.datetime(1997, 1, 1),
+                datetime.datetime(1962, 1, 1),
+                datetime.datetime(2003, 11, 10, 10, 2, 5),
+                datetime.datetime(2022, 1, 1),
+                ],
+            "RoE": [0.05, -0.05, 0.15, 1.05, -0.02, np.nan, 0.08, 0.05],
+            "revenue": [
+                50_000_000.4387,
+                np.nan,
+                63_000_000.4387,
+                25_000.4387,
+                25_000_000.4387,
+                -50_000_000.4387,
+                76_000_000.4387,
+                25_000.4387,
+                ],
+            }
+        )
+    example_df.set_index("client", inplace=True)
+
+    styled = example_df.style.applymap(lambda i: '', subset=pd.IndexSlice[:, ['last_contact', 'revenue']])
+    styled_example_df_html = DataFrameToHTML(df=styled)
+    styled_example_df_html.col_num_fmt_auto()
+    styled_example_df_html.col_styles(column=['last_contact', 'revenue'], classes=['bg_light_blue'], css_style={})
+
+    email_body_markdown = """
+Hi,
+
+This is a test email with **bold text**, *italic text*, ~~strikethrough text~~, <mark>highlited text</mark>, [hyperlink text](https://www.google.com), and text that could be footnoted<note>[1]</note>.
+
+""" + str(styled_example_df_html) + """
+
+# This would be a Heading 1 of an ordered list
+
+1. First step
+2. Second step
+3. Third step
+
+## This would be a Heading 2 of an unordered list
+
+- bullet point one
+- bullet point two
+- bullet point three
+
+### This would be a Heading 3 of a table
+
+| Syntax | Description |
+| ----------- | ----------- |
+| Header | Title |
+| Paragraph | Text |
+
+#### This would be a Heading 4 of a text blocks
+
+Code block:
+```python
+{
+  "firstName": "John",
+  "lastName": "Smith",
+  "age": 25
+}
+```
+
+Text block/quote:
+> This has to be a very
+>  
+> very important person's quote
+
+
+<footnote><note>[1]</note> Very important footnote</footnote>
+"""
+
+    with unittest.mock.patch('smtplib.SMTP', autospec=True) as mock:
+        with Connection() as conn:
+            conn.conn = mock
+            status = conn.send_email(
+                from_='test@test.com',
+                to_='test@test.com',
+                subject='My Email subject',
+                body_markdown=email_body_markdown,
+                attachments=['../README.md'],
+                dry_run=False
+                )
+
+            with open('email.html', 'w') as file:
+                file.write(status['Body'])
+            conn.save_sent_email_summary('.')
+
+    assert True


### PR DESCRIPTION

- [Fix number formatting, add css styles, and add email example to docs #patch](https://github.com/vanalmsick/beautifulemail/commit/81d3018d0892905fd208b9801664cc9bb2d33274)
- [Add backwards compability with py-3.7 removing pandas kwargs that are not supported #patch](https://github.com/vanalmsick/beautifulemail/commit/0d2ff298fe8755f789f4eae7d81b196e47e1201f)
- [Add missing packages for github testing workflow #patch](https://github.com/vanalmsick/beautifulemail/commit/4de443875f5a7e0005d962ebf58b4ae4f3f48d8f)
- [Added tests & github testing workflow, and implemented _standarise_email() #patch](https://github.com/vanalmsick/beautifulemail/commit/a1de4554997668e47b5d3dd5c4d46a316a7d9c57)